### PR TITLE
Auditing contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # Gitbook temp folder
 _book
+
+# dapptools
+/out

--- a/packages/contracts/Auditing.sol
+++ b/packages/contracts/Auditing.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.4.21;
+
+/// @title Auditing smart contract for melon.
+contract Auditing {
+
+    struct Audit {
+        address auditor;
+        bytes32 dataHash;
+        bytes32 signature;
+        // absolute unix timestamp (seconds since 1970-01-01)
+        uint timestamp;
+    }
+
+    // events
+    event AuditReported(address fundAddress, uint position); // maybe log value types (address, bytes32...)
+
+    // for this mapping, a getter is created 
+    // where we can retrieve audits by its fundAddress and position
+    mapping(address => Audit[]) public fundAudits;
+
+    /// Create a new audit on a fund specified with `fundAddress`,
+    /// the hashed data in `dataHash` and a `signature`.
+    function audit(address fundAddress, bytes32 dataHash, bytes32 signature) public {
+        // requires?
+        // TODO
+        Audit memory newAudit = Audit(msg.sender, dataHash, signature, now);
+        fundAudits[fundAddress].push(newAudit);
+
+        // signature contains vrs
+        // check: ecrecover(datahash, v, r, s) == msg.sender
+
+        uint index = fundAudits[fundAddress].length - 1;
+        emit AuditReported(fundAddress, index);
+    }
+
+    // function verifyAudit(fundaddress, datahash, signature, auditor)
+    // return bool if audit is on the blockchain (present in fundAudits)
+
+    /// Get the last audit stored for a specific `fundAddress`.
+    function getLastAudit(address fundAddress) 
+        public view 
+        returns (address auditor, bytes32 dataHash, bytes32 signature, uint timestamp) {
+        Audit memory lastAudit = fundAudits[fundAddress][fundAudits[fundAddress].length - 1];
+        auditor = lastAudit.auditor;
+        dataHash = lastAudit.dataHash;
+        signature = lastAudit.signature;
+        timestamp = lastAudit.timestamp;
+    }
+
+    /// Get the amount of audits for a specific `fundAddress`
+    function getAuditCount(address fundAddress)
+        public view
+        returns (uint count) {
+        count = fundAudits[fundAddress].length;
+    }
+
+}

--- a/packages/contracts/Auditing.sol
+++ b/packages/contracts/Auditing.sol
@@ -12,7 +12,7 @@ contract Auditing {
     }
 
     // events
-    event AuditReported(address fundAddress, uint position); // maybe log value types (address, bytes32...)
+    event AuditReported(address fundAddress, uint index);
 
     // for this mapping, a getter is created 
     // where we can retrieve audits by its fundAddress and position
@@ -22,10 +22,10 @@ contract Auditing {
     /// the hashed data in `dataHash` and a `signature`.
     function audit(address fundAddress, bytes32 dataHash, bytes32 signature) public {
         // requires?
-        // TODO
         Audit memory newAudit = Audit(msg.sender, dataHash, signature, now);
         fundAudits[fundAddress].push(newAudit);
 
+        // TODO
         // signature contains vrs
         // check: ecrecover(datahash, v, r, s) == msg.sender
 
@@ -33,13 +33,10 @@ contract Auditing {
         emit AuditReported(fundAddress, index);
     }
 
-    // function verifyAudit(fundaddress, datahash, signature, auditor)
-    // return bool if audit is on the blockchain (present in fundAudits)
-
     /// Get the last audit stored for a specific `fundAddress`.
     function getLastAudit(address fundAddress) 
-        public view 
-        returns (address auditor, bytes32 dataHash, bytes32 signature, uint timestamp) {
+            public view 
+            returns (address auditor, bytes32 dataHash, bytes32 signature, uint timestamp) {
         Audit memory lastAudit = fundAudits[fundAddress][fundAudits[fundAddress].length - 1];
         auditor = lastAudit.auditor;
         dataHash = lastAudit.dataHash;
@@ -49,9 +46,23 @@ contract Auditing {
 
     /// Get the amount of audits for a specific `fundAddress`
     function getAuditCount(address fundAddress)
-        public view
-        returns (uint count) {
+            public view
+            returns (uint count) {
         count = fundAudits[fundAddress].length;
+    }
+
+    /// Returns true if the audit is on the blockchain (present in fundAudits)
+    function verifyAudit(address fundAddress, bytes32 dataHash, bytes32 signature, address auditor)
+            public view
+            returns (bool found) {
+        Audit[] memory audits = fundAudits[fundAddress];
+        for (uint i = 0; i < audits.length; i++) {
+            Audit memory tempAudit = audits[i];
+            if (tempAudit.auditor == auditor && tempAudit.dataHash == dataHash && tempAudit.signature == signature) {
+                return true;
+            }
+        }
+        return false; // audit not found
     }
 
 }


### PR DESCRIPTION
This is a first draft of the auditing contract.
Auditors are able to create an audit on a fund by providing the fund address, a data hash and a signature.
It is possible to get the last audit on a fund, retrieve audits by index and verify the existence of an audit.
Signature checking is implemented but not tested.
An event is fired when an audit is successfully created on the blockchain.